### PR TITLE
Fix parallel execution: use 'gemini' command instead of 'gemini-cli'

### DIFF
--- a/.agent/skills/superpowers-workflow/scripts/spawn_subagent.py
+++ b/.agent/skills/superpowers-workflow/scripts/spawn_subagent.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Spawn an isolated Gemini CLI subagent for focused task execution.
 
-This enables parallel execution by launching independent gemini-cli instances
+This enables parallel execution by launching independent gemini instances
 with isolated context and specific skill instructions.
 """
 
@@ -101,7 +101,7 @@ When complete, output:
 """
 
     # Build command
-    cmd = ["gemini-cli"]
+    cmd = ["gemini"]
     if yolo:
         cmd.append("--yolo")
 

--- a/.agent/workflows/superpowers-execute-plan-parallel.md
+++ b/.agent/workflows/superpowers-execute-plan-parallel.md
@@ -176,7 +176,7 @@ After all batches complete:
 ## Troubleshooting
 
 ### Subagent spawn fails
-- Check that `gemini-cli` is in PATH
+- Check that `gemini` is in PATH (verify with: `gemini --version`)
 - Verify skill exists: `.agent/skills/superpowers-{skill}/SKILL.md`
 - Check subagent logs in `artifacts/superpowers/subagents/`
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ artifacts/
 
 - Python 3.10+
 - Antigravity installed
+- **For parallel execution:** Gemini CLI (`npm install -g @google/gemini-cli`, then verify with `gemini --version`)
 
 ### Install dependencies
 
@@ -208,7 +209,7 @@ Parallel execution spawns isolated subagents to execute independent plan steps s
 
 1. The workflow analyzes your plan for dependencies
 2. Groups steps into batches (Batch 1: independent steps, Batch 2: depends on Batch 1, etc.)
-3. Spawns isolated `gemini-cli` subagents for each step in a batch
+3. Spawns isolated `gemini` subagents for each step in a batch
 4. Each subagent has focused context (only sees its step + skill instructions)
 5. Results are consolidated and verified after each batch
 


### PR DESCRIPTION
The Gemini CLI package is installed via npm as @google/gemini-cli, but the actual command to run it is 'gemini', not 'gemini-cli'.

Changes:
- Updated spawn_subagent.py to use 'gemini' command
- Updated all documentation references from 'gemini-cli' to 'gemini'
- Added prerequisite note in README about installing Gemini CLI
- Updated troubleshooting section with verification command

This fix enables parallel execution to work for users who have Gemini CLI installed via: npm install -g @google/gemini-cli