### PR TITLE
Add shell=True for Windows compatibility in spawn_subagent.py

### DIFF
--- a/.agent/skills/superpowers-workflow/scripts/spawn_subagent.py
+++ b/.agent/skills/superpowers-workflow/scripts/spawn_subagent.py
@@ -127,6 +127,7 @@ When complete, output:
                 text=True,
                 cwd=repo_root,
                 timeout=600,  # 10 minute timeout
+                shell=True,  # Required on Windows for .ps1/.cmd scripts
             )
 
             duration_s = time.time() - start_time


### PR DESCRIPTION
On Windows, the 'gemini' command is actually 'gemini.ps1' (PowerShell script) or 'gemini.cmd', which requires shell=True to execute properly via subprocess.

Without this flag, Windows raises 'The system cannot find the file specified' error because it can't directly execute .ps1/.cmd files.

Tested and confirmed working on Windows by user.